### PR TITLE
fix: Waiting for element may alredy exist

### DIFF
--- a/src/apex/buffer.ts
+++ b/src/apex/buffer.ts
@@ -56,7 +56,10 @@ export function Buffer<TBase extends Util & Events>(Base: TBase) {
           if (!buffer) return
 
           try {
-            const bufferCMDElement = await this.observer.waitFor(Selector.BufferCMDElement)
+            const bufferCMDElement = await this.observer.waitFor(
+              Selector.BufferCMDElement,
+              { within: buffer }
+            )
             const cmd = bufferCMDElement.textContent
 
             this.events.emit('new-buffer', buffer, cmd ?? undefined)
@@ -74,7 +77,10 @@ export function Buffer<TBase extends Util & Events>(Base: TBase) {
     public async createBuffer(command?: string): Promise<Element | null> {
       if (this.newBufferButton === null) return null
 
-      const bufferPromise = this.observer.waitFor(Selector.EmptyBufferNotTaken)
+      const bufferPromise = this.observer.waitFor(
+        Selector.EmptyBufferNotTaken,
+        { onlyNew: true }
+      )
 
       this.newBufferButton.click()
       const buffer = await bufferPromise

--- a/src/apex/notifications.ts
+++ b/src/apex/notifications.ts
@@ -51,10 +51,13 @@ export function Notification<TBase extends Buffer & Events & Util>(Base: TBase) 
       return alertIndex
     }
 
-    private numberAlerts(buffer: Element) {
-      this.observer.waitFor(NotificationElementSelector.AlertListItem)
-
-      const alerts = buffer?.querySelectorAll(NotificationElementSelector.AlertListItem)
+    private async numberAlerts(buffer: Element) {
+      await this.observer.waitFor(NotificationElementSelector.AlertListItem, {
+        within: buffer,
+      })
+      const alerts = buffer?.querySelectorAll(
+        NotificationElementSelector.AlertListItem
+      )
       if (!alerts) return
 
       // Add numeric index to each alert
@@ -106,7 +109,10 @@ export function Notification<TBase extends Buffer & Events & Util>(Base: TBase) 
     }
 
     public async openNotificationIndex(index: number) {
-      const alertItemsPromise = this.observer.waitFor(NotificationElementSelector.AlertListItem)
+      const alertItemsPromise = this.observer.waitFor(
+        NotificationElementSelector.AlertListItem,
+        { onlyNew: true }
+      )
       const buffer = await this.createBuffer('NOTS')
       await alertItemsPromise
       const alerts = buffer?.querySelectorAll(NotificationElementSelector.AlertListItem)

--- a/src/apex/ships.ts
+++ b/src/apex/ships.ts
@@ -86,7 +86,7 @@ export function Ships<TBase extends Events & Util>(Base: TBase) {
     }
 
     private async getShipNamesFromInventory(buffer: Element): Promise<void> {
-      await this.observer.waitFor('tr')
+      await this.observer.waitFor('tr', { within: buffer })
       const rows = buffer.querySelectorAll('tr')
       if (!rows) {
         console.debug('[PrUn Palette] Failed to find rows in inventory buffer')
@@ -114,7 +114,7 @@ export function Ships<TBase extends Events & Util>(Base: TBase) {
     }
 
     private async getShipNamesFromFleet(buffer: Element): Promise<void> {
-      await this.observer.waitFor('tr')
+      await this.observer.waitFor('tr', { within: buffer })
       const rows = buffer.querySelectorAll('tr')
       if (!rows) {
         console.debug('[PrUn Palette] Failed to find rows in fleet buffer')

--- a/src/document-observer.ts
+++ b/src/document-observer.ts
@@ -25,6 +25,12 @@ interface ElementListener {
   consume?: boolean
 }
 
+interface WaitForOptions {
+  timeout?: number
+  within?: Element
+  onlyNew?: boolean
+}
+
 export default class DocumentObserver {
   private observer: MutationObserver
   private listeners: {
@@ -92,10 +98,23 @@ export default class DocumentObserver {
     }
   }
 
-  public async waitFor(selector: string, timeout: number = 1000) {
+  public async waitFor(
+    selector: string,
+    option: WaitForOptions = {}
+  ): Promise<Element> {
+    const { timeout = 1000, onlyNew, within = document.body } = option
+
+    if (!onlyNew) {
+      const existingElement = within.querySelector(selector)
+      if (existingElement) {
+        return existingElement
+      }
+    }
+
     const deferred = new Deferred<Element>()
     const listener: ElementListener = {
-      match: (element) => {
+      match: element => {
+        if (within !== document.body && !within.contains(element)) return false
         const nodeMatches = element.matches(selector)
         const nodeHadMatchingChildren = element.querySelector(selector)
         const match = nodeMatches || !!nodeHadMatchingChildren


### PR DESCRIPTION
Using the `waitFor()` mehtod of the `DocumentObserver` may be a bit tricky as the element you are waiting for may already exist.
This will give a little more control and by default look for the element already in the DOM

- fix: Check if element we're waiting for already exists
- fix: Update usage of `waitFor()`
